### PR TITLE
Update path to legal links

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -83,7 +83,7 @@ export const CommonLinks = {
   },
   partnersRelative: {
     title: "Lending Partners",
-    href: "/legal/lending-partners/"
+    href: "/lending-partners/"
   },
   payoffRelative: {
     title: "Payoff",
@@ -91,14 +91,14 @@ export const CommonLinks = {
   },
   privacyRelative: {
     title: "Privacy Policy",
-    href: "/legal/privacy-policy/"
+    href: "/privacy-policy/"
   },
   securityRelative: {
     title: "Security",
-    href: "/legal/security/"
+    href: "/security/"
   },
   termsRelative: {
     title: "Terms of Use",
-    href: "/legal/terms-of-use/"
+    href: "/terms-of-use/"
   }
 }


### PR DESCRIPTION
Currently there is a redirect in macstadium from /legal/{page} to just /{page} for our footer links. This redirect does not exist in AWS but we should be updating the links in happy-ui so that it points to the proper URL instead of 404ing on redirect. 